### PR TITLE
fix: make theme selector work on mobile devices

### DIFF
--- a/src/app/components/theme-selector/theme-selector.html
+++ b/src/app/components/theme-selector/theme-selector.html
@@ -1,8 +1,9 @@
 <div class="fixed top-4 right-4 z-50">
-  <div class="relative group">
+  <div class="relative">
     <!-- Theme Toggle Button -->
     <button
-      class="p-3 bg-white/80 backdrop-blur-sm rounded-xl shadow-lg border border-white/20 hover:bg-white/90 transition-all duration-200 group-hover:shadow-xl"
+      class="p-3 bg-white/80 backdrop-blur-sm rounded-xl shadow-lg border border-white/20 hover:bg-white/90 transition-all duration-200"
+      [class.shadow-xl]="isDropdownOpen()"
       (click)="toggleDropdown()"
       #dropdownButton
     >
@@ -13,7 +14,13 @@
 
     <!-- Dropdown Menu -->
     <div
-      class="absolute top-full right-0 mt-2 w-72 bg-white/95 backdrop-blur-md rounded-2xl shadow-2xl border border-white/20 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300 transform scale-95 group-hover:scale-100"
+      class="absolute top-full right-0 mt-2 w-72 bg-white/95 backdrop-blur-md rounded-2xl shadow-2xl border border-white/20 transition-all duration-300 transform"
+      [class.opacity-100]="isDropdownOpen()"
+      [class.opacity-0]="!isDropdownOpen()"
+      [class.visible]="isDropdownOpen()"
+      [class.invisible]="!isDropdownOpen()"
+      [class.scale-100]="isDropdownOpen()"
+      [class.scale-95]="!isDropdownOpen()"
       #dropdown
     >
       <div class="p-4">

--- a/src/app/components/theme-selector/theme-selector.ts
+++ b/src/app/components/theme-selector/theme-selector.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy, inject } from '@angular/core';
+import { Component, ChangeDetectionStrategy, inject, signal, HostListener } from '@angular/core';
 import { ThemeService } from '../../services/theme.service';
 
 @Component({
@@ -12,13 +12,25 @@ export class ThemeSelector {
 
   protected readonly availableThemes = this.themeService.availableThemes;
   protected readonly currentTheme = this.themeService.currentTheme;
+  protected readonly isDropdownOpen = signal(false);
 
   protected selectTheme(themeId: string): void {
     this.themeService.setTheme(themeId);
+    this.isDropdownOpen.set(false); // Close dropdown after selection
   }
 
   protected toggleDropdown(): void {
-    // This will be handled by CSS hover states
+    this.isDropdownOpen.set(!this.isDropdownOpen());
+  }
+
+  @HostListener('document:click', ['$event'])
+  protected onDocumentClick(event: Event): void {
+    const target = event.target as HTMLElement;
+    const themeSelector = target.closest('app-theme-selector');
+    
+    if (!themeSelector && this.isDropdownOpen()) {
+      this.isDropdownOpen.set(false);
+    }
   }
 
   protected getThemePreviewClass(themeId: string, colorType: 'primary' | 'secondary' | 'accent'): string {


### PR DESCRIPTION
Fixes #3

## Summary
- Replace CSS hover-based dropdown with click-based toggle
- Add proper state management for dropdown visibility
- Implement click-outside functionality and auto-close after selection
- Maintain all existing animations and styling

## Test plan
- [ ] Test theme selector on mobile devices
- [ ] Verify dropdown opens/closes with clicks
- [ ] Confirm click-outside closes dropdown
- [ ] Test theme switching functionality
- [ ] Verify desktop experience unchanged

🤖 Generated with [Claude Code](https://claude.ai/code)